### PR TITLE
tprl removing exit(44) and adding dataset folder

### DIFF
--- a/src/tprl.cpp
+++ b/src/tprl.cpp
@@ -15,10 +15,10 @@
 
 tprl::tprl(Args args):counter(0),st(args.states, args.alphabet_size),rng{args.sd}{
     std::ofstream outFile(args.input_file+"_"+std::to_string(counter));
+    auto i = 0;
     num_it = static_cast<double>(args.tape_iterations) / static_cast<double>(args.num_out_lines);
-    while(true){
+    while (i++ < 10){
         step(args);
-        exit(44);
     }
 }
 


### PR DESCRIPTION
It would be nice to have the total number of files to be written as a terminal argument. 